### PR TITLE
fix(app): <Fragment> does not have the key property, so we remove it

### DIFF
--- a/apps/ui-layout/content/components/image-mousetrail.mdx
+++ b/apps/ui-layout/content/components/image-mousetrail.mdx
@@ -99,20 +99,18 @@ export default function ImageMouseTrail({
       )}
     >
       {items.map((item, index) => (
-        <>
-          <img
-            key={index}
-            className={cn(
-              "object-cover  scale-0 opacity:0 data-[status='active']:scale-100  data-[status='active']:opacity-100 transition-transform data-[status='active']:duration-500 duration-300 data-[status='active']:ease-out-expo  absolute   -translate-y-[50%] -translate-x-[50%] ",
-              imgClass
-            )}
-            data-index={index}
-            data-status='inactive'
-            src={item}
-            alt={`image-${index}`}
-            ref={refs.current[index]}
-          />
-        </>
+        <img
+          key={index}
+          className={cn(
+            "object-cover  scale-0 opacity:0 data-[status='active']:scale-100  data-[status='active']:opacity-100 transition-transform data-[status='active']:duration-500 duration-300 data-[status='active']:ease-out-expo  absolute   -translate-y-[50%] -translate-x-[50%] ",
+            imgClass
+          )}
+          data-index={index}
+          data-status='inactive'
+          src={item}
+          alt={`image-${index}`}
+          ref={refs.current[index]}
+        />
       ))}
       <article className='relative z-50 mix-blend-difference'>
         {children}


### PR DESCRIPTION
- [X] The `<Fragment>` was removed because it is unnecessary and gives an error that the key property does not exist.

### Error message:
![before](https://github.com/user-attachments/assets/0d9ca4e6-95b6-478a-afcd-1534325ec239)

### Evidence:
![before-1](https://github.com/user-attachments/assets/36ec8dac-0598-4179-bb79-10985abf78b4)

### Result:
```diff
{items.map((item, index) => (
-      <>
        <img
          key={index}
          className={cn(
            "object-cover  scale-0 opacity:0 data-[status='active']:scale-100  data-[status='active']:opacity-100 transition-transform data-[status='active']:duration-500 duration-300 data-[status='active']:ease-out-expo  absolute   -translate-y-[50%] -translate-x-[50%] ",
            imgClass
          )}
          data-index={index}
          data-status='inactive'
          src={item}
          alt={`image-${index}`}
          ref={refs.current[index]}
        />
-    </>
      ))}
```