### PR TITLE
fix: add the 'relative' tailwind css class to the section html tag to isolate the gradiant in the 'StastSection' component

### DIFF
--- a/packages/blocks/src/stats-section/stats-section.tsx
+++ b/packages/blocks/src/stats-section/stats-section.tsx
@@ -11,7 +11,7 @@ const stats = [
 
 export const StatsSection = () => {
   return (
-    <section className="py-32 px-6 bg-neutral-950 text-white min-h-screen">
+    <section className="py-32 px-6 bg-neutral-950 text-white min-h-screen relative">
       <div className="absolute bottom-0 left-0 right-0 top-0 bg-[radial-gradient(125%_125%_at_50%_10%,rgba(255,255,255,0)_40%,rgba(102,51,238,1)_100%)] pointer-events-none"></div>
       <div className="max-w-7xl mx-auto">
         <div className="grid lg:grid-cols-2 gap-24 items-center ">


### PR DESCRIPTION
Before: Floating gradient

<img width="1150" height="467" alt="image" src="https://github.com/user-attachments/assets/2d111aae-4231-490b-9d72-8d1b08572ec4" />


After: The gradient stays at the bottom of the section

<img width="1150" height="459" alt="image" src="https://github.com/user-attachments/assets/ccc0e9db-53ae-49c0-9ae5-945f70a12e90" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Stats Section component styling to improve layout positioning consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->