### PR TITLE
fix: remove trailing semicolons from ComponentCodePreview in MDX files

### DIFF
--- a/apps/ui-layout/content/components/code-tabs.mdx
+++ b/apps/ui-layout/content/components/code-tabs.mdx
@@ -38,7 +38,7 @@ export const metadata = {
   ],
 };
 
-<ComponentCodePreview name='code-tabs' jsonName='code-tabs' isFitheight />;
+<ComponentCodePreview name='code-tabs' jsonName='code-tabs' isFitheight />
 
 ## Installation
 

--- a/apps/ui-layout/content/components/masonary-grid.mdx
+++ b/apps/ui-layout/content/components/masonary-grid.mdx
@@ -31,4 +31,4 @@ export const metadata = {
   ],
 };
 
-<ComponentCodePreview name='unsplashGrid' hasReTrigger isFitheight />;
+<ComponentCodePreview name='unsplashGrid' hasReTrigger isFitheight />


### PR DESCRIPTION
## Summary

Fixed stray semicolons rendered as visible `;` text on two component pages. The `<ComponentCodePreview />` JSX tags in MDX files had a trailing `;` which MDX treated as literal text output, showing up on the live page.

## Changes

- `apps/ui-layout/content/components/code-tabs.mdx`: removed trailing `;` on line 41
- `apps/ui-layout/content/components/masonary-grid.mdx`: removed trailing `;` on line 34

## Before / After

### Code Tabs page

| Before | After |
|--------|-------|
|  <img width="3840" height="2114" alt="uil-ct-b" src="https://github.com/user-attachments/assets/481cf46c-03d7-428c-b38d-2c6c0d86155c" />  | *(semicolon removed, clean render)* |

### Masonry Grid page

| Before | After |
|--------|-------|
| <img width="3840" height="2722" alt="uil-mg-b" src="https://github.com/user-attachments/assets/5a7da221-b768-4a2c-ad19-95baedecd574" /> | *(semicolon removed, clean render)* |

## Root Cause

MDX evaluates JSX expressions, and a trailing `;` after a self-closing tag is output as a text node identical to writing `{";"}` in JSX. All other MDX files were checked and only these two were affected.

## Type of Change

- [x] Bug fix (non-breaking)

## Checklist

- [x] Reproduces locally before the fix
- [x] Fix verified locally after the change
- [x] No other MDX files affected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor formatting adjustments to documentation files for consistency with code style conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->