### PR TITLE
fix: align docs footer with content and fix mobile text truncation

### DIFF
--- a/apps/ui-layout/app/(docs-page)/components/[...slug]/page.tsx
+++ b/apps/ui-layout/app/(docs-page)/components/[...slug]/page.tsx
@@ -135,8 +135,8 @@ export default async function DocPage(props: { params: Promise<{ slug?: string[]
             </article>
             <Content />
             <ComponentPagination doc={doc} />
+            <Footer />
           </section>
-          <Footer />
           <GapPattern className='2xl:h-full lg:h-full h-full lg:block hidden 2xl:w-10 lg:w-7 w-5 border-x border-y-0 absolute -right-8 top-0' />
         </div>
         <TableOfContents toc={doc.toc} />

--- a/apps/ui-layout/components/website/footer.tsx
+++ b/apps/ui-layout/components/website/footer.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 function Footer() {
   return (
     <>
-      <footer className='xl:pb-2 p-2 mt-8 rounded-md not-prose'>
-        <p className='text-balance text-center text-sm leading-loose text-primary/90 md:text-left'>
+      <footer className='mt-8 not-prose py-6'>
+        <p className='text-sm leading-loose text-primary/90 text-center md:text-left'>
           Built by{' '}
           <a
             href='https://x.com/naymur_dev'


### PR DESCRIPTION
## Summary

Fixed two layout bugs in the docs page footer ("Built by naymur. The source code is available on GitHub."):

- **Large screens**: footer was rendered outside the `<section>` that holds all doc content, so it didn't inherit the `mx-auto` + responsive `max-w-*` constraints causing it to overflow to the left and misalign with the content above it.
- **Mobile**: `text-balance` was collapsing the available line width, cutting the text off mid-sentence at the bottom.

## Changes

- `apps/ui-layout/app/(docs-page)/components/[...slug]/page.tsx`: moved `<Footer />` inside the `<section>` so it shares the same `mx-auto` and `max-w-*` alignment as all content above it
- `apps/ui-layout/components/website/footer.tsx`: removed `text-balance`, added proper vertical padding

## Before / After

### Large Screen

| Before | After |
|--------|-------|
| <img width="1115" height="539" alt="large-before" src="https://github.com/user-attachments/assets/e88b7968-60b3-4eda-b708-f13e831d73f9" /> | <img width="1115" height="539" alt="large-after" src="https://github.com/user-attachments/assets/cbaacf17-dc02-4dfe-b3ef-f0c2f57d0261" /> |

### Mobile Screen

| Before | After |
|--------|-------|
| <img width="398" height="533" alt="mobile-before" src="https://github.com/user-attachments/assets/ec88d61b-8a52-4e04-982b-e6742e6d1b65" /> | <img width="398" height="552" alt="Screenshot 2026-05-08 at 4 26 35 AM" src="https://github.com/user-attachments/assets/4d93bfb4-12ac-450c-80cf-8f3e845fa0d8" /> |

## Root Cause

`<Footer />` was placed after the closing `</section>` tag in `page.tsx`. The section uses `mx-auto` with breakpoint-specific `max-w-*` values (`lg:max-w-140`, `xl:max-w-190`, `2xl:max-w-210`) to center and constrain content, but the footer sat in the parent div with no such constraints, stretching full width and starting at the left edge regardless of the content offset.

## Type of Change

- [x] Bug fix (non-breaking, layout only)

## Checklist

- [x] Footer aligns with doc content on all breakpoints
- [x] Full footer text visible on mobile
- [x] No regressions to content layout or prose styles (`not-prose` preserved)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated footer styling with adjusted spacing and padding.

* **Refactor**
  * Repositioned footer component within the page layout structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->