### PR TITLE
Fix slider thumb keys and update README component links

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,22 +54,22 @@ export function useMediaQuery(query: string) {
 
 ## Most Used Components
 
-- [R3F Blob Effect](https://ui-layouts.com/components/r3f-blob)
-- [Image Ripple Effect](https://ui-layouts.com/components/image-ripple-effect)
-- [Buy Me Coffee](https://ui-layouts.com/components/buy-me-coffee)
-- [Youtube Tags](https://ui-layouts.com/components/tags-input)
-- [File Upload](https://ui-layouts.com/components/file-upload)
-- [Password](https://ui-layouts.com/components/password)
-- [Range Slider](https://ui-layouts.com/components/range-slider)
-- [Motion Number](https://ui-layouts.com/components/motion-number)
-- [Embla Carousel](https://ui-layouts.com/components/embla-carousel)
-- [Sparkles](https://ui-layouts.com/components/sparkles)
-- [Drag Items](https://ui-layouts.com/components/drag-items)
-- [Timeline Animation](https://ui-layouts.com/components/timeline-animation)
-- [Clip Path Image](https://ui-layouts.com/components/clip-path-image)
-- [Buttons](https://ui-layouts.com/components/buttons)
-- [Image Mousetrail](https://ui-layouts.com/components/image-mousetrail)
-- [Image Reveal](https://ui-layouts.com/components/image-reveal)
+- [R3F Blob Effect](https://www.ui-layouts.com/components/r3f-blob)
+- [Image Ripple Effect](https://www.ui-layouts.com/components/image-ripple-effect)
+- [Buy Me Coffee](https://www.ui-layouts.com/components/buy-me-coffee)
+- [Youtube Tags](https://www.ui-layouts.com/components/tags-input)
+- [File Upload](https://www.ui-layouts.com/components/file-upload)
+- [Password](https://www.ui-layouts.com/components/password)
+- [Range Slider](https://www.ui-layouts.com/components/range-slider)
+- [Motion Number](https://www.ui-layouts.com/components/motion-number)
+- [Embla Carousel](https://www.ui-layouts.com/components/carousel)
+- [Sparkles](https://www.ui-layouts.com/components/sparkles)
+- [Drag Items](https://www.ui-layouts.com/components/drag-items)
+- [Timeline Animation](https://www.ui-layouts.com/components/timeline-animation)
+- [Clip Path Image](https://www.ui-layouts.com/components/clip-path)
+- [Buttons](https://www.ui-layouts.com/components/buttons)
+- [Image Mousetrail](https://www.ui-layouts.com/components/image-mousetrail)
+- [Image Reveal](https://www.ui-layouts.com/components/image-reveal)
 
 Visit all the [components](https://www.ui-layouts.com/components).
 

--- a/apps/ui-layout/components/ui/slider.tsx
+++ b/apps/ui-layout/components/ui/slider.tsx
@@ -29,7 +29,7 @@ const DualRangeSlider = React.forwardRef<
       </SliderPrimitive.Track>
       <>
         {initialValue.map((value, index) => (
-          <React.Fragment key={value}>
+          <React.Fragment key={`thumb-${index}`}>
             <SliderPrimitive.Thumb className='relative grid h-6 w-3 cursor-grab place-content-center dark:bg-neutral-100 bg-neutral-950 shadow-sm focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-white'>
               {label && labelPosition !== 'static' && (
                 <div


### PR DESCRIPTION
### Motivation
- Prevent React key collisions for thumbs in the dual-range slider by using stable unique keys. 
- Correct and normalize several component links and paths in the `README.md` to reflect current routes.

### Description
- Use an index-based unique key for slider thumb fragments by changing the key from `value` to ``thumb-${index}`` to avoid duplicate keys when values are identical. 
- Update multiple entries in `README.md` to fix component paths (for example `embla-carousel` → `carousel` and `clip-path-image` → `clip-path`) and perform minor formatting/whitespace cleanup.

### Testing
- Ran a TypeScript compile check with `tsc --noEmit`, which completed successfully. 
- Ran unit tests with `npm test`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a130a50f0ec832d802bcc5b98e51cc4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with refreshed installation instructions and improved component documentation links

* **Bug Fixes**
  * Improved dual-slider rendering consistency when handling multiple thumb positions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ui-layouts/uilayouts/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->